### PR TITLE
Untitled

### DIFF
--- a/aether-concurrency/src/main/java/org/sonatype/aether/extension/concurrency/DefaultFileLockManager.java
+++ b/aether-concurrency/src/main/java/org/sonatype/aether/extension/concurrency/DefaultFileLockManager.java
@@ -35,6 +35,10 @@ public class DefaultFileLockManager
     @Requirement
     private Logger logger = NullLogger.INSTANCE;
 
+    private final Map<File, FileLock> filelocks = new HashMap<File, FileLock>();
+
+    private final Map<File, AtomicInteger> count = new HashMap<File, AtomicInteger>();
+       
     /**
      * Construct with given
      * 
@@ -53,10 +57,6 @@ public class DefaultFileLockManager
     {
         super();
     }
-
-    private Map<File, FileLock> filelocks = new HashMap<File, FileLock>();
-
-    private Map<File, AtomicInteger> count = new HashMap<File, AtomicInteger>();
 
     public ExternalFileLock readLock( File file )
     {

--- a/aether-concurrency/src/main/java/org/sonatype/aether/extension/concurrency/DefaultLockManager.java
+++ b/aether-concurrency/src/main/java/org/sonatype/aether/extension/concurrency/DefaultLockManager.java
@@ -28,9 +28,9 @@ import org.codehaus.plexus.component.annotations.Component;
 public class DefaultLockManager
     implements LockManager
 {
-    private Map<File, ReentrantReadWriteLock> locks = new HashMap<File, ReentrantReadWriteLock>();
+    private final Map<File, ReentrantReadWriteLock> locks = new HashMap<File, ReentrantReadWriteLock>();
 
-    private Map<File, AtomicInteger> count = new HashMap<File, AtomicInteger>();
+    private final Map<File, AtomicInteger> count = new HashMap<File, AtomicInteger>();
 
     public Lock readLock( File file )
     {


### PR DESCRIPTION
Fix failures on OS X. This might fix win32 as well. FileLock validity must always be checked before trying to re-use them as their associated channel might have been closed.
